### PR TITLE
fix(protect): snakecase deep keys in protect call body

### DIFF
--- a/src/github_companion/core.clj
+++ b/src/github_companion/core.clj
@@ -100,10 +100,10 @@
    (merge options
           {:required-status-checks        nil
            :enforce-admins                false
-           :required-pull-request-reviews {:dismiss-stale_reviews           true
-                                           :required-approving-review-count 1
-                                           :require-code-owner-reviews      false
-                                           :dismissal-restrictions          nil}
+           :required-pull-request-reviews {:dismiss_stale_reviews           true
+                                           :required_approving_review_count 1
+                                           :require_code_owner_reviews      false
+                                           :dismissal_restrictions          {}}
            :restrictions                  nil})))
 
 (defn protect


### PR DESCRIPTION
This is necessary because [our library only does shallow map key normalization](https://github.com/Raynes/tentacles/blob/master/src/tentacles/core.clj#L11) and the API doesn't signal any errors for invalid/unknown keys.